### PR TITLE
Get the Revel mode from the REVEL_MODE environment variable (defaults to "prod")

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ $ git push heroku master
 The buildpack will detect your repository as Revel if it
 contains the `conf/app.conf` and `conf/routes` files.
 
+It's possible to specify the revel mode by setting the REVEL_MODE environment variable. "prod" will be the default mode.
+
 #### Dependencies and private repositories
 If you want to use private repositories you just need to create Godeps folder with this command:
 ```

--- a/bin/release
+++ b/bin/release
@@ -2,6 +2,13 @@
 # bin/release <build-dir>
 
 name=$(cat $1/.godir)
+
+# Get the Revel mode from the REVEL_MODE environment variable (defaults to "prod")
+env=$(echo $REVEL_MODE)
+if [ -z "$env" ]; then
+  env="prod"
+fi
+
 cat <<EOF
 ---
 config_vars:
@@ -9,7 +16,5 @@ config_vars:
   GOROOT: /app/.goroot
   GOPATH: /app/.go
 default_process_types:
-  web: revel run $name prod \$PORT
+  web: revel run $name $env \$PORT
 EOF
-
-

--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,7 @@
 name=$(cat $1/.godir)
 
 # Get the Revel mode from the REVEL_MODE environment variable (defaults to "prod")
-env=$(echo $REVEL_MODE)
+env=$REVEL_MODE
 if [ -z "$env" ]; then
   env="prod"
 fi


### PR DESCRIPTION
When deploying the buildpack takes the revel mode from the `REVEL_MODE`[1] environment variable, if this variable is not set it defaults to "prod" (so it behaves like the original script)

[1] I originally called it `REVEL_ENV` to mimic Rack's `RACK_ENV` but Revel call these environments *modes*.
