### PR TITLE
Support go1.6+ or vendor experiment, when installing dependencies.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -151,10 +151,17 @@ unset GIT_DIR # unset git dir or it will mess with goinstall
 cd $p
 if test -e $build/Godeps
 then
-    echo "-----> Copying workspace"
-    cp -R $(godep path)/* $GOPATH
-    echo "-----> Running: godep go install ${FLAGS[@]} ./..."
-    godep go install "${FLAGS[@]}" ./...
+    if test -d $build/vendor
+    then
+        # go1.6+ or GO15VENDOREXPERIMENT
+        echo "-----> Running: godep restore"
+        godep restore
+    else
+        echo "-----> Copying workspace"
+        cp -R $(godep path)/* $GOPATH
+        echo "-----> Running: godep go install ${FLAGS[@]} ./..."
+        godep go install "${FLAGS[@]}" ./...
+    fi
 else
     echo "-----> Running: go get ${FLAGS[@]} ./..."
     go get "${FLAGS[@]}" ./...


### PR DESCRIPTION
Part of our compile process is to copy vendored dependencies from `$build/Godeps/_workspace`.

However, if we're using go1.6+ or have `GO15VENDOREXPERIMENT` enabled, our dependencies are in `$build/vendor` and aren't in a form that can be copied to `$GOPATH`.

In this situation, just use `godep restore` instead to fetch and install the dependencies.